### PR TITLE
Fix #708

### DIFF
--- a/class-wcal-update.php
+++ b/class-wcal-update.php
@@ -27,7 +27,7 @@ if ( ! class_exists( 'Wcal_Update' ) ) {
 		 */
 		public static function wcal_schedule_update_action() {
 			// IMP: The default value for get option should be updated in each release to match the current version to ensure update code is not run for first time installs.
-			if ( get_option( 'wcal_previous_version', '5.8.4' ) !== WCAL_PLUGIN_VERSION && function_exists( 'as_enqueue_async_action' ) && false === as_next_scheduled_action( 'wcal_update_db' ) ) {
+			if ( get_option( 'wcal_previous_version', '5.8.5' ) !== WCAL_PLUGIN_VERSION && function_exists( 'as_enqueue_async_action' ) && false === as_next_scheduled_action( 'wcal_update_db' ) ) {
 				as_enqueue_async_action( 'wcal_update_db' );
 			}
 		}
@@ -90,7 +90,7 @@ if ( ! class_exists( 'Wcal_Update' ) ) {
 				$wcal_previous_version = get_option( 'wcal_previous_version' );
 
 				if ( wcal_common::wcal_get_version() !== $wcal_previous_version ) {
-					update_option( 'wcal_previous_version', '5.8.4' );
+					update_option( 'wcal_previous_version', '5.8.5' );
 				}
 			} else { // multi site - child sites.
 				$wcal_guest_user_id_altered = get_blog_option( $blog_id, 'wcal_guest_user_id_altered' );
@@ -103,7 +103,7 @@ if ( ! class_exists( 'Wcal_Update' ) ) {
 				$wcal_previous_version = get_blog_option( $blog_id, 'wcal_previous_version' );
 
 				if ( wcal_common::wcal_get_version() !== $wcal_previous_version ) {
-					update_blog_option( $blog_id, 'wcal_previous_version', '5.8.4' );
+					update_blog_option( $blog_id, 'wcal_previous_version', '5.8.5' );
 				}
 			}
 

--- a/includes/frontend/class-wcal-checkout-process.php
+++ b/includes/frontend/class-wcal-checkout-process.php
@@ -330,6 +330,7 @@ if ( ! class_exists( 'Wcal_Checkout_Process' ) ) {
 						$user_email    = get_option( 'admin_email' );
 						$headers[]     = 'From: Admin <' . $user_email . '>';
 						$headers[]     = 'Content-Type: text/html';
+						$user_email    = apply_filters( 'wcal_send_recovery_email_to', $user_email );
 						// Buffer.
 						ob_start();
 						// Get mail template.

--- a/readme.txt
+++ b/readme.txt
@@ -223,6 +223,9 @@ The admin can use the merge code `{{cart.unsubscribe}}' in the email templates. 
 
 == Changelog ==
 
+= 5.8.5 (27.01.2021) =
+* Tweak - Added a hook to modify the email to which recovery emails are sent. Comma separated email addresses can be added.
+
 = 5.8.4 (07.01.2021) =
 * Fix - Default template is not being created for a fresh installation.
 * Fix - Stats on the plugin dashboard do not match the Abandoned Orders tab.

--- a/woocommerce-ac.php
+++ b/woocommerce-ac.php
@@ -3,14 +3,14 @@
  * Plugin Name: Abandoned Cart Lite for WooCommerce
  * Plugin URI: http://www.tychesoftwares.com/store/premium-plugins/woocommerce-abandoned-cart-pro
  * Description: This plugin captures abandoned carts by logged-in users & emails them about it. <strong><a href="http://www.tychesoftwares.com/store/premium-plugins/woocommerce-abandoned-cart-pro">Click here to get the PRO Version.</a></strong>
- * Version: 5.8.4
+ * Version: 5.8.5
  * Author: Tyche Softwares
  * Author URI: http://www.tychesoftwares.com/
  * Text Domain: woocommerce-abandoned-cart
  * Domain Path: /i18n/languages/
  * Requires PHP: 5.6
  * WC requires at least: 3.0.0
- * WC tested up to: 4.8.0
+ * WC tested up to: 4.9.1
  *
  * @package Abandoned-Cart-Lite-for-WooCommerce
  */
@@ -118,7 +118,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
 			}
 
 			if ( ! defined( 'WCAL_PLUGIN_VERSION' ) ) {
-				define( 'WCAL_PLUGIN_VERSION', '5.8.4' );
+				define( 'WCAL_PLUGIN_VERSION', '5.8.5' );
 			}
 			$this->one_hour              = 60 * 60;
 			$this->three_hours           = 3 * $this->one_hour;


### PR DESCRIPTION
Added a filter to allow the site admin to change the email address to which recovery emails are sent. Multiple email addresses can be added separated using a comma.