### PR TITLE
Fix #737

### DIFF
--- a/includes/templates/template_1.php
+++ b/includes/templates/template_1.php
@@ -117,15 +117,6 @@ $admin_phone = get_user_meta( $uid, 'billing_phone', true );
 			}
 		}
 	</style></p><p><style type="text/css">
-		@media only screen and (max-width:480px) {
-			@-ms-viewport {
-				width: 320px;
-			}
-			@viewport {
-				width: 320px;
-			}
-		}
-	</style></p><p><style type="text/css">
 		@import url(https://fonts.googleapis.com/css?family=Lato);
 		@import url(https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700);
 		@import url(https://fonts.googleapis.com/css?family=Cabin);


### PR DESCRIPTION
An error is logged in debug.log when we try to send the test email for the default template. The error points to Emogrifier library. This is used by WC for inline css in emails. Updating the library should most likely fix the issue. Until then, I have removed some CSS which was causing the error. The default template should be checked to ensure it is displayed fine across different screen sizes such as mobiles, tablets and laptops.