### PR TITLE
Added filters on the content of tag replacements within emails; filte…

### DIFF
--- a/cron/class-wcal-cron.php
+++ b/cron/class-wcal-cron.php
@@ -179,18 +179,18 @@ if ( ! class_exists( 'Wcal_Cron' ) ) {
 											if ( true === $wcal_check_cart_total ) {
 												if ( 'GUEST' === $value->user_type ) {
 													if ( isset( $results_guest[0]->billing_first_name ) ) {
-														$email_body    = str_ireplace( '{{customer.firstname}}', apply_filters( 'wc_abandoned_cart_email_content_customer.firstname', $results_guest[0]->billing_first_name, false, $value ), $email_body );
-														$email_subject = str_ireplace( '{{customer.firstname}}', apply_filters( 'wc_abandoned_cart_email_content_customer.firstname', $results_guest[0]->billing_first_name, false, $value ), $email_subject );
+														$email_body    = str_ireplace( '{{customer.firstname}}', apply_filters( 'wcal_abandoned_cart_email_content_customer.firstname', $results_guest[0]->billing_first_name, false, $value ), $email_body );
+														$email_subject = str_ireplace( '{{customer.firstname}}', apply_filters( 'wcal_abandoned_cart_email_content_customer.firstname', $results_guest[0]->billing_first_name, false, $value ), $email_subject );
 													}
 													if ( isset( $results_guest[0]->billing_last_name ) ) {
-														$email_body = str_ireplace( '{{customer.lastname}}', apply_filters( 'wc_abandoned_cart_email_content_customer.lastname', $results_guest[0]->billing_last_name, false, $value ), $email_body );
+														$email_body = str_ireplace( '{{customer.lastname}}', apply_filters( 'wcal_abandoned_cart_email_content_customer.lastname', $results_guest[0]->billing_last_name, false, $value ), $email_body );
 													}
 													if ( isset( $results_guest[0]->billing_first_name ) && isset( $results_guest[0]->billing_last_name ) ) {
-														$email_body = str_ireplace( '{{customer.fullname}}', apply_filters( 'wc_abandoned_cart_email_content_customer.fullname', $results_guest[0]->billing_first_name . ' ' . $results_guest[0]->billing_last_name, false, $value ), $email_body );
+														$email_body = str_ireplace( '{{customer.fullname}}', apply_filters( 'wcal_abandoned_cart_email_content_customer.fullname', $results_guest[0]->billing_first_name . ' ' . $results_guest[0]->billing_last_name, false, $value ), $email_body );
 													} elseif ( isset( $results_guest[0]->billing_first_name ) ) {
-														$email_body = str_ireplace( '{{customer.fullname}}', apply_filters( 'wc_abandoned_cart_email_content_customer.fullname', $results_guest[0]->billing_first_name, false, $value ), $email_body );
+														$email_body = str_ireplace( '{{customer.fullname}}', apply_filters( 'wcal_abandoned_cart_email_content_customer.fullname', $results_guest[0]->billing_first_name, false, $value ), $email_body );
 													} elseif ( isset( $results_guest[0]->billing_last_name ) ) {
-														$email_body = str_ireplace( '{{customer.fullname}}', apply_filters( 'wc_abandoned_cart_email_content_customer.fullname', $results_guest[0]->billing_last_name, false, $value ), $email_body );
+														$email_body = str_ireplace( '{{customer.fullname}}', apply_filters( 'wcal_abandoned_cart_email_content_customer.fullname', $results_guest[0]->billing_last_name, false, $value ), $email_body );
 													}
 												} else {
 													$user_first_name      = '';
@@ -205,8 +205,8 @@ if ( ! class_exists( 'Wcal_Cron' ) ) {
 													} else {
 														$user_first_name = $user_first_name_temp;
 													}
-													$email_body          = str_ireplace( '{{customer.firstname}}', apply_filters( 'wc_abandoned_cart_email_content_customer.firstname', $user_first_name, false, $value ), $email_body );
-													$email_subject       = str_ireplace( '{{customer.firstname}}', apply_filters( 'wc_abandoned_cart_email_content_customer.firstname', $user_first_name, false, $value ), $email_subject );
+													$email_body          = str_ireplace( '{{customer.firstname}}', apply_filters( 'wcal_abandoned_cart_email_content_customer.firstname', $user_first_name, false, $value ), $email_body );
+													$email_subject       = str_ireplace( '{{customer.firstname}}', apply_filters( 'wcal_abandoned_cart_email_content_customer.firstname', $user_first_name, false, $value ), $email_subject );
 													$user_last_name      = '';
 													$user_last_name_temp = get_user_meta( $value->user_id, 'billing_last_name', true );
 													if ( isset( $user_last_name_temp ) && '' === $user_last_name_temp ) {
@@ -219,8 +219,8 @@ if ( ! class_exists( 'Wcal_Cron' ) ) {
 													} else {
 														$user_last_name = $user_last_name_temp;
 													}
-													$email_body = str_ireplace( '{{customer.lastname}}', apply_filters( 'wc_abandoned_cart_email_content_customer.lastname', $user_last_name, false, $value ), $email_body );
-													$email_body = str_ireplace( '{{customer.fullname}}', apply_filters( 'wc_abandoned_cart_email_content_customer.fullname', $user_first_name . ' ' . $user_last_name, false, $value ), $email_body );
+													$email_body = str_ireplace( '{{customer.lastname}}', apply_filters( 'wcal_abandoned_cart_email_content_customer.lastname', $user_last_name, false, $value ), $email_body );
+													$email_body = str_ireplace( '{{customer.fullname}}', apply_filters( 'wcal_abandoned_cart_email_content_customer.fullname', $user_first_name . ' ' . $user_last_name, false, $value ), $email_body );
 												}
 												$order_date = '';
 												if ( $cart_update_time > 0 ) {
@@ -228,7 +228,7 @@ if ( ! class_exists( 'Wcal_Cron' ) ) {
 													$time_format = date_i18n( get_option( 'time_format' ), $cart_update_time );
 													$order_date  = $date_format . ' ' . $time_format;
 												}
-												$email_body = str_ireplace( '{{cart.abandoned_date}}', apply_filters( 'wc_abandoned_cart_email_content_cart.abandoned_date', $order_date, false, $value ), $email_body );
+												$email_body = str_ireplace( '{{cart.abandoned_date}}', apply_filters( 'wcal_abandoned_cart_email_content_cart.abandoned_date', $order_date, false, $value ), $email_body );
 
 												$crypt_key = wcal_get_crypt_key( $value->user_email );
 												$wpdb->query( // phpcs:ignore
@@ -280,7 +280,7 @@ if ( ! class_exists( 'Wcal_Cron' ) ) {
 													$encrypt_email_sent_id_address = hash( 'sha256', $email_sent_id_address );
 													$plugins_url                   = get_option( 'siteurl' ) . '/?wcal_track_unsubscribe=wcal_unsubscribe&user_email=' . $value->user_email . '&validate=' . $validate_unsubscribe . '&track_email_id=' . $encrypt_email_sent_id_address;
 													$unsubscribe_link_track        = $plugins_url;
-													$email_body                    = str_ireplace( '{{cart.unsubscribe}}', apply_filters( 'wc_abandoned_cart_email_content_cart.unsubscribe', $unsubscribe_link_track, false, $value ), $email_body );
+													$email_body                    = str_ireplace( '{{cart.unsubscribe}}', apply_filters( 'wcal_abandoned_cart_email_content_cart.unsubscribe', $unsubscribe_link_track, false, $value ), $email_body );
 													$var                           = '';
 													if ( preg_match( '{{products.cart}}', $email_body, $matched ) ) {
 														$img_header           = __( 'Item', 'woocommerce-abandoned-cart' );
@@ -424,11 +424,11 @@ if ( ! class_exists( 'Wcal_Cron' ) ) {
                                                                 <td> ' . $cart_total . '</td>
                                                             </tr>';
 															$var             .= '</table>';
-															$email_body       = str_ireplace( '{{products.cart}}', apply_filters( 'wc_abandoned_cart_email_content_products.cart', $var, false, $value ), $email_body );
-															$email_subject    = str_ireplace( '{{product.name}}', apply_filters( 'wc_abandoned_cart_email_content_product.name', $sub_line_prod_name, false, $value ), $email_subject );
+															$email_body       = str_ireplace( '{{products.cart}}', apply_filters( 'wcal_abandoned_cart_email_content_products.cart', $var, false, $value ), $email_body );
+															$email_subject    = str_ireplace( '{{product.name}}', apply_filters( 'wcal_abandoned_cart_email_content_product.name', $sub_line_prod_name, false, $value ), $email_subject );
 														} else {
-															$email_body    = str_ireplace( '{{products.cart}}', apply_filters( 'wc_abandoned_cart_email_content_products.cart', __( 'Product no longer exists', 'woocommerce-abandoned-cart' ), false, $value ), $email_body );
-															$email_subject = str_ireplace( '{{product.name}}', apply_filters( 'wc_abandoned_cart_email_content_product.name', $sub_line_prod_name, false, $value ), $email_subject );
+															$email_body    = str_ireplace( '{{products.cart}}', apply_filters( 'wcal_abandoned_cart_email_content_products.cart', __( 'Product no longer exists', 'woocommerce-abandoned-cart' ), false, $value ), $email_body );
+															$email_subject = str_ireplace( '{{product.name}}', apply_filters( 'wcal_abandoned_cart_email_content_product.name', $sub_line_prod_name, false, $value ), $email_subject );
 														}
 													}
 

--- a/cron/class-wcal-cron.php
+++ b/cron/class-wcal-cron.php
@@ -194,18 +194,18 @@ if ( ! class_exists( 'Wcal_Cron' ) ) {
 											if ( true === $wcal_check_cart_total ) {
 												if ( 'GUEST' === $value->user_type ) {
 													if ( isset( $results_guest[0]->billing_first_name ) ) {
-														$email_body    = str_ireplace( '{{customer.firstname}}', $results_guest[0]->billing_first_name, $email_body );
-														$email_subject = str_ireplace( '{{customer.firstname}}', $results_guest[0]->billing_first_name, $email_subject );
+														$email_body    = str_ireplace( '{{customer.firstname}}', apply_filters( 'wc_abandoned_cart_email_content_customer.firstname', $results_guest[0]->billing_first_name, false, $value ), $email_body );
+														$email_subject = str_ireplace( '{{customer.firstname}}', apply_filters( 'wc_abandoned_cart_email_content_customer.firstname', $results_guest[0]->billing_first_name, false, $value ), $email_subject );
 													}
 													if ( isset( $results_guest[0]->billing_last_name ) ) {
-														$email_body = str_ireplace( '{{customer.lastname}}', $results_guest[0]->billing_last_name, $email_body );
+														$email_body = str_ireplace( '{{customer.lastname}}', apply_filters( 'wc_abandoned_cart_email_content_customer.lastname', $results_guest[0]->billing_last_name, false, $value ), $email_body );
 													}
 													if ( isset( $results_guest[0]->billing_first_name ) && isset( $results_guest[0]->billing_last_name ) ) {
-														$email_body = str_ireplace( '{{customer.fullname}}', $results_guest[0]->billing_first_name . ' ' . $results_guest[0]->billing_last_name, $email_body );
+														$email_body = str_ireplace( '{{customer.fullname}}', apply_filters( 'wc_abandoned_cart_email_content_customer.fullname', $results_guest[0]->billing_first_name . ' ' . $results_guest[0]->billing_last_name, false, $value ), $email_body );
 													} elseif ( isset( $results_guest[0]->billing_first_name ) ) {
-														$email_body = str_ireplace( '{{customer.fullname}}', $results_guest[0]->billing_first_name, $email_body );
+														$email_body = str_ireplace( '{{customer.fullname}}', apply_filters( 'wc_abandoned_cart_email_content_customer.fullname', $results_guest[0]->billing_first_name, false, $value ), $email_body );
 													} elseif ( isset( $results_guest[0]->billing_last_name ) ) {
-														$email_body = str_ireplace( '{{customer.fullname}}', $results_guest[0]->billing_last_name, $email_body );
+														$email_body = str_ireplace( '{{customer.fullname}}', apply_filters( 'wc_abandoned_cart_email_content_customer.fullname', $results_guest[0]->billing_last_name, false, $value ), $email_body );
 													}
 												} else {
 													$user_first_name      = '';
@@ -220,8 +220,8 @@ if ( ! class_exists( 'Wcal_Cron' ) ) {
 													} else {
 														$user_first_name = $user_first_name_temp;
 													}
-													$email_body          = str_ireplace( '{{customer.firstname}}', $user_first_name, $email_body );
-													$email_subject       = str_ireplace( '{{customer.firstname}}', $user_first_name, $email_subject );
+													$email_body          = str_ireplace( '{{customer.firstname}}', apply_filters( 'wc_abandoned_cart_email_content_customer.firstname', $user_first_name, false, $value ), $email_body );
+													$email_subject       = str_ireplace( '{{customer.firstname}}', apply_filters( 'wc_abandoned_cart_email_content_customer.firstname', $user_first_name, false, $value ), $email_subject );
 													$user_last_name      = '';
 													$user_last_name_temp = get_user_meta( $value->user_id, 'billing_last_name', true );
 													if ( isset( $user_last_name_temp ) && '' === $user_last_name_temp ) {
@@ -234,8 +234,8 @@ if ( ! class_exists( 'Wcal_Cron' ) ) {
 													} else {
 														$user_last_name = $user_last_name_temp;
 													}
-													$email_body = str_ireplace( '{{customer.lastname}}', $user_last_name, $email_body );
-													$email_body = str_ireplace( '{{customer.fullname}}', $user_first_name . ' ' . $user_last_name, $email_body );
+													$email_body = str_ireplace( '{{customer.lastname}}', apply_filters( 'wc_abandoned_cart_email_content_customer.lastname', $user_last_name, false, $value ), $email_body );
+													$email_body = str_ireplace( '{{customer.fullname}}', apply_filters( 'wc_abandoned_cart_email_content_customer.fullname', $user_first_name . ' ' . $user_last_name, false, $value ), $email_body );
 												}
 												$order_date = '';
 												if ( $cart_update_time > 0 ) {
@@ -243,7 +243,7 @@ if ( ! class_exists( 'Wcal_Cron' ) ) {
 													$time_format = date_i18n( get_option( 'time_format' ), $cart_update_time );
 													$order_date  = $date_format . ' ' . $time_format;
 												}
-												$email_body = str_ireplace( '{{cart.abandoned_date}}', $order_date, $email_body );
+												$email_body = str_ireplace( '{{cart.abandoned_date}}', apply_filters( 'wc_abandoned_cart_email_content_cart.abandoned_date', $order_date, false, $value ), $email_body );
 
 												$wpdb->query( // phpcs:ignore
 													$wpdb->prepare(
@@ -286,7 +286,7 @@ if ( ! class_exists( 'Wcal_Cron' ) ) {
 														$cart_link_track     .= '&c=' . $encypted_coupon_code;
 													}
 
-													$email_body           = str_ireplace( '{{cart.link}}', $cart_link_track, $email_body );
+													$email_body           = str_ireplace( '{{cart.link}}', add_filters( 'wc_abandoned_cart_email_content_cart.link', $cart_link_track, false, $value ), $email_body );
 													$validate_unsubscribe = wcal_common::wcal_encrypt_validate( $email_sent_id );
 													if ( count( $results_sent ) > 0 && isset( $results_sent[0]->sent_email_id ) ) {
 														$email_sent_id_address = $results_sent[0]->sent_email_id;
@@ -294,7 +294,7 @@ if ( ! class_exists( 'Wcal_Cron' ) ) {
 													$encrypt_email_sent_id_address = hash( 'sha256', $email_sent_id_address );
 													$plugins_url                   = get_option( 'siteurl' ) . '/?wcal_track_unsubscribe=wcal_unsubscribe&validate=' . $validate_unsubscribe . '&track_email_id=' . $encrypt_email_sent_id_address;
 													$unsubscribe_link_track        = $plugins_url;
-													$email_body                    = str_ireplace( '{{cart.unsubscribe}}', $unsubscribe_link_track, $email_body );
+													$email_body                    = str_ireplace( '{{cart.unsubscribe}}', apply_filters( 'wc_abandoned_cart_email_content_cart.unsubscribe', $unsubscribe_link_track, false, $value ), $email_body );
 													$var                           = '';
 													if ( preg_match( '{{products.cart}}', $email_body, $matched ) ) {
 														$img_header           = __( 'Item', 'woocommerce-abandoned-cart' );
@@ -438,11 +438,11 @@ if ( ! class_exists( 'Wcal_Cron' ) ) {
                                                                 <td> ' . $cart_total . '</td>
                                                             </tr>';
 															$var             .= '</table>';
-															$email_body       = str_ireplace( '{{products.cart}}', $var, $email_body );
-															$email_subject    = str_ireplace( '{{product.name}}', $sub_line_prod_name, $email_subject );
+															$email_body       = str_ireplace( '{{products.cart}}', apply_filters( 'wc_abandoned_cart_email_content_products.cart', $var, false, $value ), $email_body );
+															$email_subject    = str_ireplace( '{{product.name}}', apply_filters( 'wc_abandoned_cart_email_content_product.name', $sub_line_prod_name, false, $value ), $email_subject );
 														} else {
-															$email_body    = str_ireplace( '{{products.cart}}', __( 'Product no longer exists', 'woocommerce-abandoned-cart' ), $email_body );
-															$email_subject = str_ireplace( '{{product.name}}', $sub_line_prod_name, $email_subject );
+															$email_body    = str_ireplace( '{{products.cart}}', apply_filters( 'wc_abandoned_cart_email_content_products.cart', __( 'Product no longer exists', 'woocommerce-abandoned-cart' ), false, $value ), $email_body );
+															$email_subject = str_ireplace( '{{product.name}}', apply_filters( 'wc_abandoned_cart_email_content_product.name', $sub_line_prod_name, false, $value ), $email_subject );
 														}
 													}
 

--- a/cron/class-wcal-cron.php
+++ b/cron/class-wcal-cron.php
@@ -286,7 +286,7 @@ if ( ! class_exists( 'Wcal_Cron' ) ) {
 														$cart_link_track     .= '&c=' . $encypted_coupon_code;
 													}
 
-													$email_body           = str_ireplace( '{{cart.link}}', add_filters( 'wc_abandoned_cart_email_content_cart.link', $cart_link_track, false, $value ), $email_body );
+													$email_body           = str_ireplace( '{{cart.link}}', apply_filters( 'wc_abandoned_cart_email_content_cart.link', $cart_link_track, false, $value ), $email_body );
 													$validate_unsubscribe = wcal_common::wcal_encrypt_validate( $email_sent_id );
 													if ( count( $results_sent ) > 0 && isset( $results_sent[0]->sent_email_id ) ) {
 														$email_sent_id_address = $results_sent[0]->sent_email_id;

--- a/woocommerce-ac.php
+++ b/woocommerce-ac.php
@@ -4182,7 +4182,6 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
 				}
 
 				$body_email_preview = str_ireplace( '{{customer.firstname}}', apply_filters( 'wcal_abandoned_cart_email_content_customer_firstname', 'John', true, null ), $body_email_preview );
-				$body_email_preview = str_ireplace( '{{customer.firstname}}', apply_filters( 'wcal_abandoned_cart_email_content_customer_firstname', 'John', true, null ), $body_email_preview );
 				$body_email_preview = str_ireplace( '{{customer.lastname}}', apply_filters( 'wcal_abandoned_cart_email_content_customer_lastname', 'Doe', true, null ), $body_email_preview );
 				$body_email_preview = str_ireplace( '{{customer.fullname}}', apply_filters( 'wcal_abandoned_cart_email_content_customer_fullname', 'John Doe', true, null ), $body_email_preview );
 				$current_time_stamp = current_time( 'timestamp' ); // phpcs:ignore

--- a/woocommerce-ac.php
+++ b/woocommerce-ac.php
@@ -4005,23 +4005,23 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
 				$from_email_preview    = get_option( 'wcal_reply_email' );
 				$subject_email_preview = isset( $_POST['subject_email_preview'] ) ? stripslashes( sanitize_text_field( wp_unslash( $_POST['subject_email_preview'] ) ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
 				$subject_email_preview = convert_smilies( $subject_email_preview );
-				$subject_email_preview = str_ireplace( '{{customer.firstname}}', 'John', $subject_email_preview );
+				$subject_email_preview = str_ireplace( '{{customer.firstname}}', apply_filters( 'wc_abandoned_cart_email_content_customer_firstname', 'John', true, null ), $subject_email_preview );
 				$body_email_preview    = isset( $_POST['body_email_preview'] ) ? convert_smilies( wp_unslash( $_POST['body_email_preview'] ) ) : ''; // phpcs:ignore
 				$is_wc_template        = isset( $_POST['is_wc_template'] ) ? sanitize_text_field( wp_unslash( $_POST['is_wc_template'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
 				$wc_template_header    = isset( $_POST['wc_template_header'] ) ? stripslashes( sanitize_text_field( wp_unslash( $_POST['wc_template_header'] ) ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
 
-				$body_email_preview = str_ireplace( '{{customer.firstname}}', 'John', $body_email_preview );
-				$body_email_preview = str_ireplace( '{{customer.firstname}}', 'John', $body_email_preview );
-				$body_email_preview = str_ireplace( '{{customer.lastname}}', 'Doe', $body_email_preview );
-				$body_email_preview = str_ireplace( '{{customer.fullname}}', 'John Doe', $body_email_preview );
+				$body_email_preview = str_ireplace( '{{customer.firstname}}', apply_filters( 'wc_abandoned_cart_email_content_customer_firstname', 'John', true, null ), $body_email_preview );
+				$body_email_preview = str_ireplace( '{{customer.firstname}}', apply_filters( 'wc_abandoned_cart_email_content_customer_firstname', 'John', true, null ), $body_email_preview );
+				$body_email_preview = str_ireplace( '{{customer.lastname}}', apply_filters( 'wc_abandoned_cart_email_content_customer_lastname', 'Doe', true, null ), $body_email_preview );
+				$body_email_preview = str_ireplace( '{{customer.fullname}}', apply_filters( 'wc_abandoned_cart_email_content_customer_fullname', 'John Doe', true, null ), $body_email_preview );
 				$current_time_stamp = current_time( 'timestamp' ); // phpcs:ignore
 				$date_format        = date_i18n( get_option( 'date_format' ), $current_time_stamp );
 				$time_format        = date_i18n( get_option( 'time_format' ), $current_time_stamp );
 				$test_date          = $date_format . ' ' . $time_format;
-				$body_email_preview = str_ireplace( '{{cart.abandoned_date}}', $test_date, $body_email_preview );
+				$body_email_preview = str_ireplace( '{{cart.abandoned_date}}', apply_filters( 'wc_abandoned_cart_email_content_cart_abandoned_date', $test_date, true, null ), $body_email_preview );
 				$cart_url           = wc_get_page_permalink( 'cart' );
-				$body_email_preview = str_ireplace( '{{cart.link}}', $cart_url, $body_email_preview );
-				$body_email_preview = str_ireplace( '{{cart.unsubscribe}}', '#', $body_email_preview );
+				$body_email_preview = str_ireplace( '{{cart.link}}', apply_filters( 'wc_abandoned_cart_email_content_cart_link', $cart_url, true, null ), $body_email_preview );
+				$body_email_preview = str_ireplace( '{{cart.unsubscribe}}', apply_filters( 'wc_abandoned_cart_email_content_cart_unsubscribe', '#', true, null ), $body_email_preview );
 				$wcal_price         = wc_price( '100' );
 				$wcal_total_price   = wc_price( '200' );
 				if ( class_exists( 'WP_Better_Emails' ) ) {
@@ -4095,7 +4095,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
 											</tr>
 										 </table>';
 				}
-				$body_email_preview = str_ireplace( '{{products.cart}}', $var, $body_email_preview );
+				$body_email_preview = str_ireplace( '{{products.cart}}', apply_filters( 'wc_abandoned_cart_email_content_products.cart', $var, true, null ), $body_email_preview );
 				if ( isset( $_POST['send_email_id'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 					$to_email_preview = sanitize_text_field( wp_unslash( $_POST['send_email_id'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
 				} else {

--- a/woocommerce-ac.php
+++ b/woocommerce-ac.php
@@ -4148,7 +4148,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
 				$from_email_preview    = get_option( 'wcal_reply_email' );
 				$subject_email_preview = isset( $_POST['subject_email_preview'] ) ? stripslashes( sanitize_text_field( wp_unslash( $_POST['subject_email_preview'] ) ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
 				$subject_email_preview = convert_smilies( $subject_email_preview );
-				$subject_email_preview = str_ireplace( '{{customer.firstname}}', apply_filters( 'wc_abandoned_cart_email_content_customer_firstname', 'John', true, null ), $subject_email_preview );
+				$subject_email_preview = str_ireplace( '{{customer.firstname}}', apply_filters( 'wcal_abandoned_cart_email_content_customer_firstname', 'John', true, null ), $subject_email_preview );
 				$body_email_preview    = isset( $_POST['body_email_preview'] ) ? convert_smilies( wp_unslash( $_POST['body_email_preview'] ) ) : ''; // phpcs:ignore
 				$is_wc_template        = isset( $_POST['is_wc_template'] ) ? sanitize_text_field( wp_unslash( $_POST['is_wc_template'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
 				$wc_template_header    = isset( $_POST['wc_template_header'] ) ? stripslashes( sanitize_text_field( wp_unslash( $_POST['wc_template_header'] ) ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
@@ -4181,18 +4181,18 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
 					$body_email_preview   = str_ireplace( '{{coupon.code}}', $coupon_code_to_apply, $body_email_preview );
 				}
 
-				$body_email_preview = str_ireplace( '{{customer.firstname}}', apply_filters( 'wc_abandoned_cart_email_content_customer_firstname', 'John', true, null ), $body_email_preview );
-				$body_email_preview = str_ireplace( '{{customer.firstname}}', apply_filters( 'wc_abandoned_cart_email_content_customer_firstname', 'John', true, null ), $body_email_preview );
-				$body_email_preview = str_ireplace( '{{customer.lastname}}', apply_filters( 'wc_abandoned_cart_email_content_customer_lastname', 'Doe', true, null ), $body_email_preview );
-				$body_email_preview = str_ireplace( '{{customer.fullname}}', apply_filters( 'wc_abandoned_cart_email_content_customer_fullname', 'John Doe', true, null ), $body_email_preview );
+				$body_email_preview = str_ireplace( '{{customer.firstname}}', apply_filters( 'wcal_abandoned_cart_email_content_customer_firstname', 'John', true, null ), $body_email_preview );
+				$body_email_preview = str_ireplace( '{{customer.firstname}}', apply_filters( 'wcal_abandoned_cart_email_content_customer_firstname', 'John', true, null ), $body_email_preview );
+				$body_email_preview = str_ireplace( '{{customer.lastname}}', apply_filters( 'wcal_abandoned_cart_email_content_customer_lastname', 'Doe', true, null ), $body_email_preview );
+				$body_email_preview = str_ireplace( '{{customer.fullname}}', apply_filters( 'wcal_abandoned_cart_email_content_customer_fullname', 'John Doe', true, null ), $body_email_preview );
 				$current_time_stamp = current_time( 'timestamp' ); // phpcs:ignore
 				$date_format        = date_i18n( get_option( 'date_format' ), $current_time_stamp );
 				$time_format        = date_i18n( get_option( 'time_format' ), $current_time_stamp );
 				$test_date          = $date_format . ' ' . $time_format;
-				$body_email_preview = str_ireplace( '{{cart.abandoned_date}}', apply_filters( 'wc_abandoned_cart_email_content_cart_abandoned_date', $test_date, true, null ), $body_email_preview );
+				$body_email_preview = str_ireplace( '{{cart.abandoned_date}}', apply_filters( 'wcal_abandoned_cart_email_content_cart_abandoned_date', $test_date, true, null ), $body_email_preview );
 				$cart_url           = wc_get_page_permalink( 'cart' );
-				$body_email_preview = str_ireplace( '{{cart.link}}', apply_filters( 'wc_abandoned_cart_email_content_cart_link', $cart_url, true, null ), $body_email_preview );
-				$body_email_preview = str_ireplace( '{{cart.unsubscribe}}', apply_filters( 'wc_abandoned_cart_email_content_cart_unsubscribe', '#', true, null ), $body_email_preview );
+				$body_email_preview = str_ireplace( '{{cart.link}}', apply_filters( 'wcal_abandoned_cart_email_content_cart_link', $cart_url, true, null ), $body_email_preview );
+				$body_email_preview = str_ireplace( '{{cart.unsubscribe}}', apply_filters( 'wcal_abandoned_cart_email_content_cart_unsubscribe', '#', true, null ), $body_email_preview );
 				$wcal_price         = wc_price( '100' );
 				$wcal_total_price   = wc_price( '200' );
 				if ( class_exists( 'WP_Better_Emails' ) ) {
@@ -4266,7 +4266,7 @@ if ( ! class_exists( 'woocommerce_abandon_cart_lite' ) ) {
 											</tr>
 										 </table>';
 				}
-				$body_email_preview = str_ireplace( '{{products.cart}}', apply_filters( 'wc_abandoned_cart_email_content_products.cart', $var, true, null ), $body_email_preview );
+				$body_email_preview = str_ireplace( '{{products.cart}}', apply_filters( 'wcal_abandoned_cart_email_content_products.cart', $var, true, null ), $body_email_preview );
 				if ( isset( $_POST['send_email_id'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 					$to_email_preview = sanitize_text_field( wp_unslash( $_POST['send_email_id'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
 				} else {


### PR DESCRIPTION
I added filters so that the mail tag replacements can be overridden with code, which allows better customization of the mail contents

apply_filter(`wc_abandoned_cart_email_content_<tag>`, mixed $filtered_value, bool $is_test, mixed $cart_contents);