### PR TITLE
Notice changes continue

### DIFF
--- a/assets/js/admin/tyche-dismiss-tracking-notice.js
+++ b/assets/js/admin/tyche-dismiss-tracking-notice.js
@@ -28,14 +28,21 @@ jQuery(document).ready( function() {
 				if ( $this.hasClass( 'wcal-upgrade-to-pro-notice' ) ) {
 					data = {
 						action: 'wcal_dismiss_upgrade_to_pro',
+						upgrade_to_pro_type: 'purchase',
 						security: wcal_ts_dismiss_notice_params.tracking_notice
-					}
+					};
+				} else if ( $this.hasClass( 'wcal-pro-expired-notice' ) ) {
+					data = {
+						action: 'wcal_dismiss_upgrade_to_pro',
+						upgrade_to_pro_type: 'expired',
+						security: wcal_ts_dismiss_notice_params.tracking_notice
+					};
 				} else {
 					data = {
 						action: wcal_ts_dismiss_notice_params.ts_prefix_of_plugin + "_tracker_dismiss_notice",
 						tracking_notice : wcal_ts_dismiss_notice_params.tracking_notice,
 						security: wcal_ts_dismiss_notice_params.tracking_notice
-					}
+					};
 				}
 				jQuery(this).slideUp( 100, function() {
 					jQuery.post(


### PR DESCRIPTION
In this commit, I have shown the upgrade to pro notice only on the AC settings page and added the option of dismissing it. Also, there was a conflict when using AC and Orddd lite on the same store.